### PR TITLE
small bug fix, stops seg faulting bug

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -21,6 +21,7 @@ playBorder pborder;
 SpriteRenderer * spriteRenderer;
 Simulation simulation;
 ECS ecs;
+ECS::Entity entity1 = ecs.CreateEntity();
 std::vector<Button> Buttons;
 
 Game::Game(unsigned int width, unsigned int height)
@@ -94,7 +95,6 @@ void Game::Render() {
     }
   }
 
-  ECS::Entity entity1 = ecs.CreateEntity();
   entity1 = ecs.AddComponent(entity1, DIMENSIONID);
   if (ecs.EntityHasComponent(entity1, DIMENSIONID)) {
     spriteRenderer->DrawSprite(texture,


### PR DESCRIPTION
Program was seg faulting because I tested the ECS in the render loop, and included a CreateEntity() call in the render loop. This caused an entity to be created every frame, and eventually surpassed the amount allotted to it.